### PR TITLE
Implement hash and eq on declarations

### DIFF
--- a/src/syntax.py
+++ b/src/syntax.py
@@ -1329,7 +1329,7 @@ class SortDecl(Decl):
 
     def __getstate__(self) -> Any:
         return dict(
-            self.__dict__,
+            super().__getstate__(),
             z3=None,
         )
 
@@ -1367,7 +1367,7 @@ class FunctionDecl(Decl):
 
     def __getstate__(self) -> Any:
         return dict(
-            self.__dict__,
+            super().__getstate__(),
             mut_z3={},
             immut_z3=None,
         )
@@ -1426,7 +1426,7 @@ class RelationDecl(Decl):
 
     def __getstate__(self) -> Any:
         return dict(
-            self.__dict__,
+            super().__getstate__(),
             mut_z3={},
             immut_z3=None,
         )
@@ -1494,7 +1494,7 @@ class ConstantDecl(Decl):
 
     def __getstate__(self) -> Any:
         return dict(
-            self.__dict__,
+            super().__getstate__(),
             mut_z3={},
             immut_z3=None,
         )

--- a/src/test.py
+++ b/src/test.py
@@ -104,6 +104,10 @@ class SyntaxTests(unittest.TestCase):
 
         self.assertEqual(syntax.relativize_quantifiers(guards, e), expected)
 
+    def test_decls_eq(self) -> None:
+        s1 = syntax.SortDecl(None, 'foo', [])
+        s2 = syntax.SortDecl(None, 'foo', [])
+        self.assertEqual(s1, s2)
 
 def build_python_cmd() -> List[str]:
     python = os.getenv('PYTHON') or 'python3.7'


### PR DESCRIPTION
This is a significant change to the philosophy of mypyvy. Up to now, we have considered declarations of various kinds as unique. But to support caching and updates to transition systems, now we consider declarations equivalent when they have the same name and metadata. 

It would not surprise me if this introduces a few bugs elsewhere in mypyvy, which will be discovered as we exercise the system.