### PR TITLE
specify mypyvy comment syntax in mypyvy-mode

### DIFF
--- a/emacs/mypyvy-mode.el
+++ b/emacs/mypyvy-mode.el
@@ -43,6 +43,7 @@
 (define-derived-mode mypyvy-mode prog-mode "Mypyvy"
   "Major mode for editing Mypyvy proof files"
   :syntax-table mypyvy-mode-syntax-table
+  (setq-local comment-start "#")
   (set (make-local-variable 'font-lock-defaults) '(mypyvy-font-lock-keywords))
   (font-lock-fontify-buffer)
   (set (make-local-variable 'compile-command)


### PR DESCRIPTION
very small change, but will allow people who use emacs commands like `comment-or-uncomment-lines` to do so without having to first specify the comment syntax.