### PR TITLE
Disable old() syntax by default

### DIFF
--- a/regression/191125-theorem.pyv
+++ b/regression/191125-theorem.pyv
@@ -1,4 +1,4 @@
-# MYPYVY: theorem --no-print-counterexample --no-query-time --error-filename-basename --no-print-cmdline --print-exit-code
+# MYPYVY: theorem --no-print-counterexample --no-query-time --error-filename-basename --no-print-cmdline --print-exit-code --accept-old
 
 sort A
 immutable relation lt(A,A)

--- a/regression/191205-def-order.pyv
+++ b/regression/191205-def-order.pyv
@@ -1,4 +1,4 @@
-# MYPYVY: typecheck --print-exit-code --error-filename-basename
+# MYPYVY: typecheck --print-exit-code --error-filename-basename --accept-old
 
 sort A
 

--- a/src/mypyvy.py
+++ b/src/mypyvy.py
@@ -631,7 +631,7 @@ def parse_args(args: List[str]) -> utils.MypyvyArgs:
                        help='assert that the discovered states already contain all the answers')
         s.add_argument('--print-exit-code', action=utils.YesNoAction, default=False,
                        help='print the exit code before exiting (good for regression testing)')
-        s.add_argument('--accept-old', action=utils.YesNoAction, default=True,
+        s.add_argument('--accept-old', action=utils.YesNoAction, default=False,
                        help='allow deprecated syntax using old()')
 
         s.add_argument('--cvc4', action='store_true',

--- a/src/syntax.py
+++ b/src/syntax.py
@@ -2018,7 +2018,7 @@ class DefinitionDecl(Decl):
             mod.resolve(scope)
 
         if self.num_states == 2:
-            if not uses_old(self.expr) and not uses_new(self.expr):
+            if utils.args.accept_old and not uses_old(self.expr) and not uses_new(self.expr):
                 utils.print_error(self.span, 'twostate expression uses neither old() nor new(); '
                                   'cannot automatically detect whether it needs to be translated')
 
@@ -2170,7 +2170,7 @@ class TheoremDecl(Decl):
 
     def resolve(self, scope: Scope) -> None:
         if self.num_states == 2:
-            if not uses_old(self.expr) and not uses_new(self.expr):
+            if utils.args.accept_old and not uses_old(self.expr) and not uses_new(self.expr):
                 utils.print_error(self.span, 'twostate expression uses neither old() nor new(); '
                                   'cannot automatically detect whether it needs to be translated')
 


### PR DESCRIPTION
It can still be supported via the `--accept-old` command line option.