### PR TITLE
Allow referring to the new state via primed symbols

### DIFF
--- a/examples/lockserv_prime.pyv
+++ b/examples/lockserv_prime.pyv
@@ -1,0 +1,58 @@
+# a copy of lockserv_clean.pyv that uses primes instead of new()
+
+sort node
+
+mutable relation lock_msg(node)
+mutable relation grant_msg(node)
+mutable relation unlock_msg(node)
+mutable relation holds_lock(node)
+mutable relation server_holds_lock()
+
+init !lock_msg(N)
+init !grant_msg(N)
+init !unlock_msg(N)
+init !holds_lock(N)
+init server_holds_lock
+
+transition send_lock(n: node)
+  modifies lock_msg
+  lock_msg'(N) <-> lock_msg(N) | N = n
+
+transition recv_lock(n: node)
+  modifies lock_msg, server_holds_lock, grant_msg
+  server_holds_lock &
+  lock_msg(n) &
+  !server_holds_lock' &
+  (lock_msg'(N) <-> lock_msg(N) & N != n) &
+  (grant_msg'(N) <-> grant_msg(N) | N = n)
+
+transition recv_grant(n: node)
+  modifies grant_msg, holds_lock
+  grant_msg(n) &
+  (grant_msg'(N) <-> grant_msg(N) & N != n) &
+  (holds_lock'(N) <-> holds_lock(N) | N = n)
+
+transition unlock(n: node)
+  modifies holds_lock, unlock_msg
+  holds_lock(n) &
+  (holds_lock'(N) <-> holds_lock(N) & N != n) &
+  (unlock_msg'(N) <-> unlock_msg(N) | N = n)
+
+transition recv_unlock(n: node)
+  modifies unlock_msg, server_holds_lock
+  unlock_msg(n) &
+  (unlock_msg'(N) <-> unlock_msg(N) & N != n) &
+  server_holds_lock'
+
+safety [mutex] holds_lock(N1) & holds_lock(N2) -> N1 = N2
+
+invariant grant_msg(N1) & grant_msg(N2) -> N1 = N2
+invariant unlock_msg(N1) & unlock_msg(N2) -> N1 = N2
+
+invariant !(holds_lock(N1) & grant_msg(N2))
+invariant !(holds_lock(N1) & unlock_msg(N2))
+invariant !(grant_msg(N1) & unlock_msg(N2))
+
+invariant !(grant_msg(N) & server_holds_lock)
+invariant !(holds_lock(N) & server_holds_lock)
+invariant !(unlock_msg(N) & server_holds_lock)

--- a/examples/pd/tlb_safety_prime.pyv
+++ b/examples/pd/tlb_safety_prime.pyv
@@ -1,0 +1,474 @@
+# a copy of tlb_safety.pyv that uses primes instead of new()
+
+
+
+################################################################################
+#
+# The protocol itself.  This closely follows the algorithm written in Figure 9 of
+#
+#  J. Hoenicke, R. Majumdar, A. Podelski: Thread Modularity at Many Levels. POPL 2017
+#
+# The locations match the line number in the figure.
+#
+################################################################################
+
+# this file has been manually translated from Ivy to mypyvy
+
+# we distinguish between processors and pagemaps -- the above paper misused
+# processors for both.
+#
+# pageentry is an abstract type to represent the value in a pagemap (the paper used integers).
+#
+sort processor
+sort pmap
+sort pageentry
+
+# the locations closely match the line numbers in Figure 9
+# sort location = {i1,i2,i3,i4,i5,i6,i7,i8,i9,i11,i12,i14,i15,
+#                  m2,m3,m5,
+#                  r1,r2,r3,r5,r6,r7,r8,
+#                  b1}
+sort location @no_minimize @printed_by(const_printer) @no_print
+
+immutable constant i1: location   @no_print
+immutable constant i2: location   @no_print
+immutable constant i3: location   @no_print
+immutable constant i4: location   @no_print
+immutable constant i5: location   @no_print
+immutable constant i6: location   @no_print
+immutable constant i7: location   @no_print
+immutable constant i8: location   @no_print
+immutable constant i9: location   @no_print
+immutable constant i11: location  @no_print
+immutable constant i12: location  @no_print
+immutable constant i14: location  @no_print
+immutable constant i15: location  @no_print
+immutable constant m2: location   @no_print
+immutable constant m3: location   @no_print
+immutable constant m5: location   @no_print
+immutable constant r1: location   @no_print
+immutable constant r2: location   @no_print
+immutable constant r3: location   @no_print
+immutable constant r5: location   @no_print
+immutable constant r6: location   @no_print
+immutable constant r7: location   @no_print
+immutable constant r8: location   @no_print
+immutable constant b1: location   @no_print
+
+
+axiom distinct(i1,i2,i3,i4,i5,i6,i7,i8,i9,i11,i12,i14,i15,m2,m3,m5,r1,r2,r3,r5,r6,r7,r8,b1)
+
+axiom forall L:location.
+    L = i1 | L = i2 | L = i3 | L = i4 | L = i5 | L = i6 | L = i7 | L = i8 | L = i9 | L = i11 | L = i12 | L = i14 | L = i15 |
+    L = m2 | L = m3 | L = m5 |
+    L = r1 | L = r2 | L = r3 | L = r5 | L = r6 | L = r7 | L = r8 |
+    L = b1
+
+
+mutable function pc(processor):location
+
+mutable function userpmap(processor):pmap
+# this variable is called pmap in the paper
+mutable function writepmap(processor):pmap
+mutable relation actionlock(processor)
+mutable relation actionneeded(processor)
+mutable relation active(processor)
+mutable relation interrupt(processor)
+# this represents the cpu variable as relation
+mutable relation currentcpu(processor, processor)
+mutable relation plock(pmap)
+mutable function tlb(processor):pageentry
+mutable function pentry(pmap):pageentry
+
+# elements to iterate in the for cpu != pid loops.
+mutable relation todo(processor, processor)
+
+# error is set if some assertions fails, e.g. lock not held on unlock.
+mutable relation error
+
+init pc(P)=b1
+init !currentcpu(P,C)
+init !plock(P)
+init !actionlock(P) & !actionneeded(P) & !interrupt(P) & active(P)
+init !error
+
+# i1: active := false   we also havoc writepmap here
+transition initiator1(p:processor, m:pmap)
+  modifies active, writepmap, pc
+    & pc(p) = i1
+    & (forall P. active'(P) <-> active(P) & P != p)
+    & (forall P. P != p -> writepmap'(P) = writepmap(P))
+    & writepmap'(p) = m
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i2
+
+
+# i2: lock plock(writepmap)
+# Also prepares for cpu != pid loop.
+# Note that we busy-loop if lock is taken.  This is necessary to
+# detect deadlock as non-terminating runs.
+transition initiator2(p:processor)
+  modifies pc, plock, todo
+    & pc(p) = i2
+    & if !plock(writepmap(p)) then
+        & (forall P. plock'(P) <-> plock(P) | P = writepmap(p))
+        & (forall P,X. P != p -> (todo'(P,X) <-> todo(P,X)))
+        & (forall X. todo'(p,X) <-> pc(X) != b1 & p != X)
+        & (forall P. P != p -> pc'(P) = pc(P))
+        & pc'(p) = i3
+      else  # nop
+        & (forall P. plock'(P) <-> plock(P))
+        & (forall P,X. todo'(P,X) <-> todo(P,X))
+        & (forall P. pc'(P) = pc(P))
+
+
+# i3: for cpu != pid
+# This translates for (cpu != pid)
+# if todo contains a cpu, it is set in the currentcpu relation and we enter the loop
+transition initiator3(p:processor, cpu:processor)
+  modifies currentcpu, todo, pc
+    & pc(p) = i3
+    & todo(p, cpu)
+    & (forall P,X. P != p -> (currentcpu'(P,X) <-> currentcpu(P,X)))
+    & (forall X. currentcpu'(p,X) <-> X = cpu)
+    & (forall P,X. todo'(P,X) <-> todo(P,X) & !(P = p & X = cpu))
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i4
+
+
+# Otherwise if todo list is empty, we leave the loop
+# and prepare the next for pid != cpu loop.
+transition initiator3exit(p:processor)
+  modifies todo, pc
+    & pc(p) = i3
+    & (forall X. !todo(p, X))
+    & (forall P,X. P != p -> (todo'(P,X) <-> todo(P,X)))
+    & (forall X. todo'(p, X) <-> pc'(X) != b1 & X != p)
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i9
+
+# i4:    if userpmap[cpu] = pmap
+transition initiator4(p:processor, cpu:processor)
+  modifies pc
+  & pc(p) = i4
+  & currentcpu(p, cpu)
+  & (forall P. P != p -> pc'(P) = pc(P))
+  & if userpmap(cpu) = writepmap(p)
+    then pc'(p) = i5
+    else pc'(p) = i3
+
+# i5:        lock actionlock[cpu]
+transition initiator5(p:processor, cpu:processor)
+  modifies actionlock, pc
+    & pc(p) = i5
+    & currentcpu(p, cpu)
+    & if !actionlock(cpu)
+      then
+        & (forall C. actionlock'(C) <-> actionlock(C) | C = cpu)
+        & (forall P. P != p -> pc'(P) = pc(P))
+        & pc'(p) = i6
+      else
+        & (forall C. actionlock'(C) <-> actionlock(C))
+        & (forall P. pc'(P) = pc(P))
+
+# i6:        actionneeded[cpu] := true
+transition initiator6(p:processor, cpu:processor)
+  modifies actionneeded, pc
+    & pc(p) = i6
+    & currentcpu(p, cpu)
+    & (forall C. actionneeded'(C) <-> actionneeded(C) | C = cpu)
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i7
+
+# i7:        unlock actionlock[cpu]
+transition initiator7(p:processor, cpu:processor)
+  modifies error, actionlock, pc
+    & pc(p) = i7
+    & currentcpu(p, cpu)
+    & if !actionlock(cpu)
+      then error'
+      else error' = error
+    & (forall C. actionlock'(C) <-> actionlock(C) & C != cpu)
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i8
+
+# i8:        interrupt[cpu] := true
+transition initiator8(p:processor, cpu:processor)
+  modifies interrupt, pc
+    & pc(p) = i8
+    & currentcpu(p, cpu)
+    & (forall C. interrupt'(C) <-> interrupt(C) | C = cpu)
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i3
+
+# i9: for cpu != pid
+# i10:    wait until !active[cpu] | userpmap[cpu] != writepmap
+transition initiator9(p:processor, cpu:processor)
+  modifies todo
+    & pc(p) = i9
+    & todo(p, cpu)
+    & if !active(cpu) | userpmap(cpu) != writepmap(p)
+      then
+        (forall P,C. todo'(P,C) <-> todo(P,C) & !(P = p & C = cpu))
+      else
+        (forall P,C. todo'(P,C) <-> todo(P,C))
+
+transition initiator9exit(p:processor)
+  modifies pc
+    & pc(p) = i9
+    & (forall X. !todo(p, X))
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i11
+
+# i11: entry[pmap] := *
+transition initiator11(p:processor, e:pageentry)
+  modifies pentry, pc
+    & pc(p) = i11
+    & (forall P. P != writepmap(p) -> pentry'(P) = pentry(P))
+    & pentry'(writepmap(p)) = e
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i12
+
+# i12: if (userpmap = pmap)
+# i13:    tlb := entry[pmap]
+transition initiator12(p:processor)
+  modifies tlb, pc
+    & pc(p) = i12
+    & (if userpmap(p) = writepmap(p)
+       then
+         & (forall P. P != p -> tlb'(P) = tlb(P))
+         & tlb'(p) = pentry(writepmap(p))
+       else
+         (forall P. tlb'(P) = tlb(P)))
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i14
+
+# i14: unlock plock[pmap]
+transition initiator14(p:processor)
+  modifies error, plock, pc
+    & pc(p) = i14
+    & (if !plock(writepmap(p))
+       then
+         error'
+       else
+         (error' <-> error))
+    & (forall P. P != writepmap(p) -> (plock'(P) <-> plock(P)))
+    & !plock'(writepmap(p))
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i15
+
+# i15: active := true
+transition initiator15(p:processor)
+  modifies active, pc
+    & pc(p) = i15
+    & (forall P. P != p -> active'(P) = active(P))
+    & active'(p)
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = m5
+
+# r1: while actionneeded
+transition responder1(p:processor)
+  modifies pc
+    & pc(p) = r1
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = (if actionneeded(p) then r2 else m2)
+
+# r2:   active := false
+transition responder2(p:processor)
+  modifies active, pc
+    & pc(p) = r2
+    & (forall P. P != p -> active'(P) = active(P))
+    & active'(p) = false
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = r3
+
+# this must be atomic (bug in original TLB algorithm, see paper)
+# r3:   wait until plock[userpmap] = unlocked
+# r4:   lock actionlock(p)
+transition responder3(p:processor)
+  modifies error, actionlock, pc
+    & pc(p)=r3
+    & if !plock(userpmap(p))
+      then
+        & (error' <-> error | actionlock(p))
+        & (forall P. P != p -> (actionlock'(P) <-> actionlock(P)))
+        & actionlock'(p)
+        & (forall P. P != p -> pc'(P) = pc(P))
+        & pc'(p) = r5
+      else
+        & (error' <-> error)
+        & (forall P. actionlock'(P) <-> actionlock(P))
+        & (forall P. pc'(P) = pc(P))
+
+# r5:   tlb := entry[userpmap]
+transition responder5(p:processor)
+  modifies tlb, pc
+    & pc(p) = r5
+    & (forall P. P != p -> tlb'(P) = tlb(P))
+    & tlb'(p) = pentry(userpmap(p))
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = r6
+
+
+# r6:   actionneeded := false
+transition responder6(p:processor)
+  modifies actionneeded, pc
+    & pc(p) = r6
+    & (forall P. P != p -> (actionneeded'(P) <-> actionneeded(P)))
+    & !actionneeded'(p)
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = r7
+
+# r7:   unlock actionlock
+transition responder7(p:processor)
+  modifies error, actionlock, pc
+    & pc(p) = r7
+    & (error' <-> error | !actionlock(p))
+    & (forall P. P != p -> (actionlock'(P) <-> actionlock(P)))
+    & !actionlock'(p)
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = r8
+
+# r8:   active := false
+transition responder8(p:processor)
+  modifies active, pc
+    & pc(p) = r8
+    & (forall P. P != p -> (active'(P) <-> active(P)))
+    & active'(p)
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = r1
+
+
+# # m1: while true
+# # m2:    assert tlb = entry[userpmap]
+transition main2(p:processor)
+  modifies error, pc
+    & pc(p) = m2
+    & (error' <-> error | tlb(p) != pentry(userpmap(p)))
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = m3
+
+# # m3:    if (*)
+# # m4:        Initiator()
+transition main3a(p:processor)
+  modifies pc
+    & pc(p) = m3
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = i1
+
+transition main3b(p:processor)
+  modifies pc
+    & pc(p) = m3
+    & (forall P. P != p -> pc'(P) = pc(P))
+    & pc'(p) = m5
+
+# # m5:    if (interrupt)
+# # m6:        interrupt := false Responder()
+transition main5(p:processor)
+  modifies interrupt, pc
+    & pc(p)=m5
+    & if interrupt(p)
+      then
+        & (forall P. interrupt'(P) <-> interrupt(P) & P != p)
+        & (forall P. P != p -> pc'(P) = pc(P))
+        & pc'(p) = r1
+     else
+        & (forall P. interrupt'(P) <-> interrupt(P))
+        & (forall P. P != p -> pc'(P) = pc(P))
+        & pc'(p) = m2
+
+# # b1: pid := ++n  // create process
+# # b2: atomic userpmap := *
+# #            assume plock[userpmap] = unlocked
+# #            tlb := entry[userpmap]
+# # b3: Main()
+
+####### this action is not exported in the ivy model, nor is it used anywhere
+
+# transition boot1(p:processor, m:pmap)
+#   modifies userpmap, tlb, pc
+#     & old(pc(p)) = b1
+#     & !old(plock(m))
+#     & (forall P. P != p -> userpmap(P) = old(userpmap(P)))
+#     & userpmap(p) = m
+#     & (forall P. P != p -> tlb(P) = old(tlb(P)))
+#     & tlb(p) = old(pentry(m))
+#     & (forall P. P != p -> pc(P) = old(pc(P)))
+#     & pc(p) = m2
+
+# show safety
+# all invariants are universal with at most two variables (provable at level 2)
+
+# plock(writemap) is taken in i3-i14
+invariant pc(P)=i3 | pc(P)=i4 | pc(P)=i5 | pc(P)=i6 | pc(P)=i7 | pc(P)=i8 | pc(P)=i9 | pc(P)=i11 | pc(P)=i12 | pc(P)=i14 -> plock(writepmap(P))
+# plock(writemap) ensures mutual exclusion of i3-i14
+invariant (pc(P1)=i3 | pc(P1)=i4 | pc(P1)=i5 | pc(P1)=i6 | pc(P1)=i7 | pc(P1)=i8 | pc(P1)=i9 | pc(P1)=i11 | pc(P1)=i12 | pc(P1)=i14)
+         & (pc(P2)=i3 | pc(P2)=i4 | pc(P2)=i5 | pc(P2)=i6 | pc(P2)=i7 | pc(P2)=i8 | pc(P2)=i9 | pc(P2)=i11 | pc(P2)=i12 | pc(P2)=i14)
+         -> writepmap(P1) != writepmap(P2) | P1 = P2
+
+# currentcpu has at most one value
+invariant currentcpu(P,C1) & currentcpu(P, C2) -> C1 = C2
+
+# actionlock(cpu) is taken in i6-i7
+invariant (pc(P)=i6 | pc(P)=i7) & currentcpu(P, C) -> actionlock(C)
+# actionlock(p) is taken in r5-r7
+invariant (pc(P)=r5 | pc(P)=r6 | pc(P)=r7) -> actionlock(P)
+# actionlock(p) ensures mutual exclusion of i6-i7
+invariant (pc(P1)=i6 | pc(P1)=i7) & currentcpu(P1, C) & (pc(P2)=i6 | pc(P2)=i7) & currentcpu(P2, C) -> P1 = P2
+# actionlock(p) ensures mutual exclusion of r5-r7 and i6-i7
+invariant !((pc(P1)=r5 | pc(P1)=r6 | pc(P1)=r7) & (pc(P2)=i6 | pc(P2)=i7) & currentcpu(P2, P1))
+
+# while actionlock(p) is taken outside r5-r7 it can only be if someone is in i6-i7, so plock(userpmap) should hold
+invariant actionlock(C) & !(pc(C)=r5 | pc(C)=r6 | pc(C)=r7) -> plock(userpmap(C))
+# and then no other process with the same writemap can be in i3-i14
+invariant actionlock(C) & !(pc(C)=r5 | pc(C)=r6 | pc(C)=r7) &
+   (pc(P)=i3 | pc(P)=i4 | pc(P)=i5 | pc(P)=i6 | pc(P)=i7 | pc(P)=i8 | pc(P)=i9 | pc(P)=i11 | pc(P)=i12 | pc(P)=i14) ->
+   userpmap(C) != writepmap(P) | (currentcpu(P,C) & (pc(P)=i6 | pc(P)=i7))
+
+# instructions i5-i7 are only executed if writepmap = userpmap(cpu)
+invariant (pc(P)=i5 | pc(P)=i6 | pc(P)=i7) & currentcpu(P,C) -> writepmap(P) = userpmap(C)
+
+# active is only exactly set in these limited locations
+invariant active(P) <->
+  (pc(P)=b1 | pc(P)=m2 | pc(P)=m3 | pc(P) = m5 | pc(P) = i1 | pc(P) = r1 | pc(P) = r2)
+
+# If we already iterated over a process C in the i3-i8 loop of P or if we are currently iterating and we
+# are past the i6 instruction, and userpmap(C) = writepmap(P) then we set the actionneeded flag, so it is
+# still set and C cannot enter the actionlock
+invariant (pc(P)=i3 | pc(P)=i7 | pc(P)=i8) & !todo(P,C) & pc(C) != b1 & userpmap(C) = writepmap(P) -> (actionneeded(C) & pc(C)!=r5  & pc(C)!=r6) | P = C
+invariant (pc(P)=i4 | pc(P)=i5 | pc(P)=i6) & !todo(P,C) & !currentcpu(P,C) & pc(C) != b1 & userpmap(C) = writepmap(P) -> (actionneeded(C) & pc(C)!=r5  & pc(C)!=r6) | P = C
+# The same if we are in the i9 loop or in i11
+invariant (pc(P)=i9 | pc(P)=i11) & pc(C) != b1 & userpmap(C) = writepmap(P) -> (actionneeded(C) & pc(C)!=r5  & pc(C)!=r6) | P = C
+
+# When the tlb(P) is incorrect actionneded(P) is still set (unless we changed our own tlb, but then
+# we are in i12 where we fix it in the next step)
+# invariant pc(P) != b1 & tlb(P) != pentry(userpmap(P)) -> (actionneeded(P) & pc(P)!=r6) | (pc(P)=i12 & userpmap(P) = writepmap(P))
+# rewritten to use function depth 1:
+invariant pc(P) != b1 & M = userpmap(P) & tlb(P) != pentry(M) -> (actionneeded(P) & pc(P)!=r6) | (pc(P)=i12 & M = writepmap(P))
+
+# If we already iterated over a process C in the i3-i8 loop of P and userpmap(C) = writepmap(P) then
+# we set the interrupt flag, so it is still set or C is in the interrupt routine
+invariant (pc(P)=i3) & !todo(P,C) & pc(C) != b1 & userpmap(C) = writepmap(P) -> interrupt(C) | P = C | (pc(C)=r1 | pc(C)=r2 | pc(C)=r3)
+invariant (pc(P)=i4 | pc(P)=i5 | pc(P)=i6 | pc(P)=i7 | pc(P)=i8) & !todo(P,C) & pc(C) != b1 & !currentcpu(P,C) & userpmap(C) = writepmap(P) -> interrupt(C) | P = C | (pc(C)=r1 | pc(C)=r2 | pc(C)=r3)
+invariant (pc(P)=i9 | pc(P)=i11) & pc(C) != b1 & userpmap(C) = writepmap(P) -> interrupt(C) | P = C | (pc(C)=r1 | pc(C)=r2 | pc(C)=r3)
+# When the tlb(C) is incorrect the process must be interrupted
+# invariant tlb(C) != pentry(userpmap(C)) & pc(C) != b1 -> interrupt(C) | (pc(C)=r1 | pc(C)=r2 | pc(C)=r3 | pc(C) = r5) | (pc(C)=i12 & writepmap(C) = userpmap(C))
+# rewritten to use function depth 1:
+invariant M = userpmap(C) & tlb(C) != pentry(M) & pc(C) != b1 -> interrupt(C) | (pc(C)=r1 | pc(C)=r2 | pc(C)=r3 | pc(C) = r5) | (pc(C)=i12 & writepmap(C) = userpmap(C))
+
+# We wait for a process in the i9 loop at least until it leaves m2 and it cannot enter m2 again before i11
+invariant ((pc(P)=i9 & !todo(P,C)) | pc(P)=i11) & userpmap(C) = writepmap(P) -> pc(C)!=m2
+# When the tlb(C) is incorrect the process is not in m2
+# invariant tlb(P) != pentry(userpmap(P)) -> pc(P)!=m2
+# rewritten to use function depth 1:
+invariant M = userpmap(P) & tlb(P) != pentry(M) -> pc(P)!=m2
+
+
+safety !error
+
+# updr infers the following trivial invariant proving that no process ever boots
+# invariant forall P:processor. pc(P) = b1
+# invariant forall P:processor, C:processor. !currentcpu(P, C)
+# invariant forall P:pmap. !plock(P)
+# invariant forall P:processor. !actionlock(P) & !actionneeded(P) & !interrupt(P) & active(P)
+# invariant !error

--- a/src/translator.py
+++ b/src/translator.py
@@ -87,10 +87,10 @@ class Z3Translator:
         with self.scope.n_states(self.num_states):
             return self.__translate_expr(expr)
 
-    def _decl_to_z3(self, d: syntax.StateDecl) -> Union[z3.FuncDeclRef, z3.ExprRef]:
+    def _decl_to_z3(self, d: syntax.StateDecl, n_new: int = 0) -> Union[z3.FuncDeclRef, z3.ExprRef]:
         return Z3Translator.statedecl_to_z3(
             d,
-            self.get_key(self.scope.current_state_index)
+            self.get_key(self.scope.current_state_index + n_new)
             if d.mutable else None
         )
 
@@ -114,17 +114,20 @@ class Z3Translator:
             return self.z3_NOPS[expr.op]([self.__translate_expr(arg) for arg in expr.args])
         elif isinstance(expr, AppExpr):
             d = self.scope.get(expr.callee)
+
+            # TODO: handling definitions should be refactored out of Z3Translator
             if isinstance(d, DefinitionDecl):
-                # TODO: handling definitions should be refactored out of Z3Translator
                 # checked by typechecker; see NOTE(calling-stateful-definitions)
-                assert self.scope.current_state_index + d.num_states <= self.scope.num_states, f'{d}\n{expr}'
+                assert self.scope.current_state_index + d.num_states + expr.n_new <= self.scope.num_states, \
+                    f'{d}\n{expr}'
                 # now translate args in the scope of caller
                 translated_args = [self.__translate_expr(arg) for arg in expr.args]
                 with self.scope.fresh_stack():
                     with self.scope.in_scope(d.binder, translated_args):
-                        return self.__translate_expr(d.expr)  # translate body of def in fresh scope
+                        with self.scope.next_state_index(expr.n_new):
+                            return self.__translate_expr(d.expr)  # translate body of def in fresh scope
             elif isinstance(d, (RelationDecl, FunctionDecl)):
-                callee = self._decl_to_z3(d)
+                callee = self._decl_to_z3(d, expr.n_new)
                 assert isinstance(callee, z3.FuncDeclRef), f'{callee}\n{expr}'
                 return callee(*(
                     self.__translate_expr(arg)
@@ -141,15 +144,15 @@ class Z3Translator:
             d = self.scope.get(expr.name)
             assert d is not None, f'{expr.name}\n{expr}'
             if isinstance(d, (RelationDecl, ConstantDecl)):
-                z3sym = self._decl_to_z3(d)
+                z3sym = self._decl_to_z3(d, expr.n_new)
                 assert isinstance(z3sym, z3.ExprRef)
                 return z3sym
-            elif isinstance(d, DefinitionDecl):
-                # TODO: handling definitions should be refactored out of Z3Translator
+            elif isinstance(d, DefinitionDecl):  # TODO: handling definitions should be refactored out of Z3Translator
                 # checked in typechecker; see NOTE(calling-stateful-definitions)
-                assert self.scope.current_state_index + d.num_states <= self.scope.num_states
+                assert self.scope.current_state_index + d.num_states + expr.n_new <= self.scope.num_states
                 with self.scope.fresh_stack():
-                    return self.__translate_expr(d.expr)
+                    with self.scope.next_state_index(expr.n_new):
+                        return self.__translate_expr(d.expr)
             else:
                 assert not isinstance(d, FunctionDecl)  # impossible since functions have arity > 0
                 e, = d


### PR DESCRIPTION
This PR implements an alternative to mypyvy's traditional `new` syntax. Instead of `new(c)` you can say `c'`. This is especially useful with relations and functions, as in `new(r(c))`, where the `new` syntax forces everything in its body into the next state. Using primes we can say something like `r'(c)`, which would have to be expressed as `let old_c = c in new(r(old_c))` before this PR.

The current implementation is a prototype. I'm sure there are places in the code that need to handle primes that I missed. Please let me know about any problems you find!